### PR TITLE
Check if file_exists instead of suppressing errors

### DIFF
--- a/System/Daemon.php
+++ b/System/Daemon.php
@@ -457,10 +457,22 @@ class System_Daemon
             include(dirname(__FILE__).'/'.$path);
         } else {
             // Everything else.
-            @include($path);
+            // Check for $path within each include_path
+            foreach (explode(PATH_SEPARATOR,ini_get('include_path')) as $prefix) {
+                $prefixed_path = $prefix.'/'.$path;
+                if (file_exists($prefixed_path)) {
+                    include $prefixed_path;
+                    return true;
+                }
+            }
+
+            // Since include_path might not contain current
+            // directory, we'll check that ourselves.
+            if (file_exists($path)) {
+                include $path;
+            }
         }
     }
-
 
     /**
      * Spawn daemon process.


### PR DESCRIPTION
If e.g. using xdebug with scream=1, @include "foo.php" is a rather not-so-pretty way of including files. Fixed by checking if file_exists for each include_path.
