### PR TITLE
Writing pidfile in parent

### DIFF
--- a/System/Daemon.php
+++ b/System/Daemon.php
@@ -348,6 +348,13 @@ class System_Daemon
             'detail' => 'Sometimes it\'s better to stick with the OS default,
                 and use something like /etc/default/<name> for customization',
         ),
+
+        'noFork' => array(
+            'type' => 'boolean',
+            'default' => false,
+            'punch' => 'Do not fork',
+            'detail' => 'Disables forking, damon remains in one process',
+        ),
     );
 
 


### PR DESCRIPTION
Hello.

I'm trying to manage application using this library by supervisord (http://supervisord.org/)

Because this library makes fork into the background I need to use pidproxy (as described in http://supervisord.org/subprocess.html#pidproxy-program).

The problem occurs, when parent process finishes, and child process still didn't wrote it's pidfile, and pidproxy fails because it is missing. The pidfile must be present in the directory after parent dies.

Please, move Pidfile writing to parent process, as shown in attached diff.
