### PR TITLE
Fixed appPidLocation check according to bug 20062 (PEAR)

### DIFF
--- a/System/Daemon.php
+++ b/System/Daemon.php
@@ -1452,9 +1452,7 @@ class System_Daemon
             );
         }
 
-        $pidDirPath = dirname($pidFilePath);
-        $parts      = explode('/', $pidDirPath);
-        if (count($parts) <= 3 || end($parts) != self::opt('appName')) {
+        if(basename(dirname($pidFilePath)) !== self::opt('appName')) {
             // like: /var/run/x.pid
             return self::err(
                 'Since version 0.6.3, the pidfile needs to be ' .


### PR DESCRIPTION
System_Daemon requires that pidfiles live in their own directories, like `/var/run/appName/pidfile` instead of `/var/run/appName.pid`. This is conform to the policies of most Linux distributions about `/var/run/`.

However, the existing check failed to allow locations like `/dir/appName/pidfile` or `./appName/pidfile` as it was required that the path component of `appPidLocation` requires at least three nested directories like `/var/run/appName/..`

This commit fixes this.

A further improvement might be to perform the check only if the pidfile should being placed in `/var/run/` in order to allow `./pidfile` for example.
