### PR TITLE
Replace variables when setting option values

### DIFF
--- a/System/Daemon/Options.php
+++ b/System/Daemon/Options.php
@@ -120,6 +120,22 @@ class System_Daemon_Options
             $success        = false;
         }
         
+        if (!is_bool($value)) {
+            // Replace variables
+            $value = preg_replace_callback(
+                '/\{([^\{\}]+)\}/is',
+                array($this, "replaceVars"), 
+                $value
+            );
+            
+            // Replace functions
+            $value = preg_replace_callback(
+                '/\@([\w_]+)\(([^\)]+)\)/is',
+                array($this, "replaceFuncs"), 
+                $value
+            );
+        }
+        
         $this->_options[$name] = $value;
         return $success;
     }


### PR DESCRIPTION
E.g. now it is also possible to set your logLocation as follows, previously the {OPTIONS.appName} would only be replaced when logging the filename.

$options = array(
    'appName' => 'myAppName',
    'logLocation' => __DIR__ . '/{OPTIONS.appName}.log',
);
System_Daemon::setOptions($options);